### PR TITLE
[UE-5] Init and isOn functions for wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+*/settings.json

--- a/src/uptech-growthbook-wrapper.test.ts
+++ b/src/uptech-growthbook-wrapper.test.ts
@@ -1,10 +1,34 @@
-import { UptechGrowthBookTypescriptWrapper } from "./uptech-growthbook-wrapper";
+import { UptechGrowthBookTypescriptWrapper } from './uptech-growthbook-wrapper';
+
+class ToglTest extends UptechGrowthBookTypescriptWrapper {
+
+  static instance: ToglTest = new ToglTest('https://cdn.growthbook.io/api/features/dummy-api-key');
+}
 
 describe("Uptech Growthbook Wrapper", () => {
-    describe("isAwesome", () => {
-        it("should return true", () => {
-            const wrapper = new UptechGrowthBookTypescriptWrapper()
-            expect(wrapper.isAwesome).toEqual(true);
+    describe("isOn", () => {
+        describe("when a feature value is present", () => {
+          beforeEach(() => {
+            ToglTest.instance.initForTests({
+              'some-feature-name': true,
+            });
           });
+  
+          it("should return true", () => {
+              expect(ToglTest.instance.isOn('some-feature-name')).toEqual(true);
+          });
+        });
+
+        describe("when a feature value is not present", () => {
+          beforeEach(() => {
+            ToglTest.instance.initForTests({
+              'some-feature-name': true,
+            });
+          });
+  
+          it("should return true", () => {
+              expect(ToglTest.instance.isOn('some-other-name')).toEqual(false);
+          });
+        });
     });
   });

--- a/src/uptech-growthbook-wrapper.ts
+++ b/src/uptech-growthbook-wrapper.ts
@@ -1,5 +1,41 @@
+import { FeatureDefinition, GrowthBook } from "@growthbook/growthbook";
+
 export class UptechGrowthBookTypescriptWrapper {
-    public get isAwesome(): boolean {
-        return true;
+    constructor(apiUrl: string) {
+        this.url = apiUrl;
+    }
+    private client: GrowthBook;
+    private readonly url: string;
+
+    public async init(seeds?: any): Promise<void> {
+        this.client = this.createClient(seeds);
+        const growthbookResult = await fetch(this.url)
+        const growthbook = await growthbookResult.json();
+        this.client.setFeatures(growthbook.features);
+    }
+
+    public initForTests(seeds: any): void {
+        this.client = this.createClient(seeds);
+    }
+
+    /// Check if a feature is on/off
+    public isOn(featureId: string): boolean {
+      return this.client.feature(featureId).on ?? false;
+    }
+
+    private createClient(seeds: Record<string, any>): GrowthBook {
+        return new GrowthBook({
+            enabled: true,
+            qaMode: false,
+            trackingCallback: (gbExperiment, gbExperimentResult) => {},
+            features: this.seedsToGBFeatures(seeds),
+        });
+    }
+    private seedsToGBFeatures(seeds: Record<string, any>): Record<string, FeatureDefinition> {
+        const features = {};
+        for (const key in seeds) {
+            features[key] = { defaultValue: seeds[key] };
+        }
+        return features;
     }
 }


### PR DESCRIPTION
The intention for this change is to add the init and initForTest functions that make this wrapper functional, along with a helper method to create the Growthbook client instance. Since the test init function is not actually making a call to the api, the fetch function is omitted from the method. The seedsToGBFeatures method formats the passed in seeds to match with the types returned from Growthbook when we fetch from the API.  The isOn method is also added to give important functionality as well as an easy method to use in testing as more features are added.

ps-id: F9AB1E3E-C8C8-41D0-AD2F-F55312FC2173