### PR TITLE
[UE-5] Add refresh toggle method

### DIFF
--- a/src/uptech-growthbook-wrapper.ts
+++ b/src/uptech-growthbook-wrapper.ts
@@ -9,13 +9,25 @@ export class UptechGrowthBookTypescriptWrapper {
 
     public async init(seeds?: any): Promise<void> {
         this.client = this.createClient(seeds);
-        const growthbookResult = await fetch(this.url)
-        const growthbook = await growthbookResult.json();
-        this.client.setFeatures(growthbook.features);
+        await this.refresh();
     }
 
     public initForTests(seeds: any): void {
         this.client = this.createClient(seeds);
+    }
+
+    /// Force a refresh of toggles from the server
+    public async refresh(): Promise<void> {
+        try {
+            const growthbookResult = await fetch(this.url)
+            const growthbook = await growthbookResult.json();
+            this.client.setFeatures(growthbook.features);
+        } catch(e) {
+            console.log({
+                message: 'Error while fetching features from GrowthBook',
+                e
+              });
+        }
     }
 
     /// Check if a feature is on/off


### PR DESCRIPTION
The intention for this change is to add a specific method for fetching the latest features from Growthbook and adding them to the wrapper's instance. Since the same work was already being done in the init function, that logic was moved to a separate public method. It also handles if the API fetch is unsuccessful by logging the error from Growthbook.

ps-id: 0FEDA8EA-3570-430C-9D30-6C564C007E75