### PR TITLE
[UE-5] Add overrides parameter to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ const port = 8080; // default port to listen
 // ...
 
 app.listen( port, () => {
-    Togls.instance.init(
+    Togls.instance.init({
 		seeds: {
 		  'example-toggle-higher-fee': false,
 		},
-	);
+	});
 } );
 
 // ...
@@ -105,7 +105,9 @@ import { Togls } from 'yourproject/togls.ts';
       describe('when example-toggle-higher-fee is off', () {
         beforeEach(() {
           Togls.instance
-              .initForTests(seeds: {'example-toggle-higher-fee': false});
+              .initForTests({
+                seeds: {'example-toggle-higher-fee': false}
+              });
         });
 
        it('returns amount with fee of 10 added', () {
@@ -116,7 +118,9 @@ import { Togls } from 'yourproject/togls.ts';
 
       describe('when example-toggle-higher-fee is on', () {
         beforeEach(() {
-          Togls.instance.initForTests(seeds: {'example-toggle-higher-fee': true});
+          Togls.instance.initForTests({
+            seeds: {'example-toggle-higher-fee': true}
+          });
         });
 
         it('returns amount with fee of 20 added', () {

--- a/src/uptech-growthbook-wrapper.test.ts
+++ b/src/uptech-growthbook-wrapper.test.ts
@@ -1,34 +1,65 @@
 import { UptechGrowthBookTypescriptWrapper } from './uptech-growthbook-wrapper';
 
-class ToglTest extends UptechGrowthBookTypescriptWrapper {
 
-  static instance: ToglTest = new ToglTest('https://cdn.growthbook.io/api/features/dummy-api-key');
-}
 
 describe("Uptech Growthbook Wrapper", () => {
+
     describe("isOn", () => {
         describe("when a feature value is present", () => {
+          const instance = new UptechGrowthBookTypescriptWrapper('https://cdn.growthbook.io/api/features/dummy-api-key');
           beforeEach(() => {
-            ToglTest.instance.initForTests({
-              'some-feature-name': true,
+            instance.initForTests({
+              seeds: new Map<string, any>().set('some-feature-name', true),
             });
           });
   
           it("should return true", () => {
-              expect(ToglTest.instance.isOn('some-feature-name')).toEqual(true);
+              expect(instance.isOn('some-feature-name')).toEqual(true);
           });
         });
 
         describe("when a feature value is not present", () => {
+          const instance = new UptechGrowthBookTypescriptWrapper('https://cdn.growthbook.io/api/features/dummy-api-key');
           beforeEach(() => {
-            ToglTest.instance.initForTests({
-              'some-feature-name': true,
+            instance.initForTests({
+              seeds: new Map<string, any>().set('some-feature-name', true),
             });
           });
   
           it("should return true", () => {
-              expect(ToglTest.instance.isOn('some-other-name')).toEqual(false);
+              expect(instance.isOn('some-other-name')).toEqual(false);
           });
         });
+
+        describe('when an override is present', () => {
+          const instance = new UptechGrowthBookTypescriptWrapper('https://cdn.growthbook.io/api/features/dummy-api-key');
+          beforeEach(() => {
+            instance.initForTests({
+              overrides: new Map<string, any>().set('some-feature-name', true),
+            });
+          });
+  
+          it('returns the overridden value', () => {
+            expect(instance.isOn('some-feature-name')).toEqual(true);
+          });
+        });
+
+        describe('when a feature env is present', () => {
+          let instance;
+          beforeEach(() => {
+            instance = new UptechGrowthBookTypescriptWrapper(
+              'https://cdn.growthbook.io/api/features/dummy-api-key',
+              (key) => 'true'
+            );
+            instance.initForTests({
+              seeds: new Map<string, any>().set('some-feature-name', false),
+            });
+          });
+
+          it('returns the overridden value', () => {
+            expect(instance.isOn('some-feature-name')).toEqual(true);
+          });
+        });
+  
     });
   });


### PR DESCRIPTION
The intention for this change is allow users to add overrides to the Growthbook features fetched at init. It is added as an optional parameter to both init functions and stored to use in the isOn method as a conditional before checking Growthbook features.

The parameters are also changed in the init functions to have to use parameter names in the function call. This allows for overrides to be added as a parameter without having to add seeds. It will also be helpful in the future when attributes are added as a parameter to init.

ps-id: D408DA4B-ADD7-4415-8E7B-2DB32185474C