### PR TITLE
[UE-5] Add rules parameter to test init

### DIFF
--- a/src/uptech-growthbook-wrapper.ts
+++ b/src/uptech-growthbook-wrapper.ts
@@ -3,7 +3,8 @@ import { FeatureDefinition, GrowthBook } from "@growthbook/growthbook";
 interface InitParameters {
     seeds?: Map<string, any>,
     overrides?: Map<string, any>,
-}
+    rules?: Array<Map<string, any>>,
+}   
 
 export class UptechGrowthBookTypescriptWrapper {
     constructor(apiUrl: string, getEnv: (key: string) => string | undefined = (key) => process.env[key]) {
@@ -26,13 +27,13 @@ export class UptechGrowthBookTypescriptWrapper {
         await this.refresh();
     }
 
-    public initForTests({seeds, overrides}: InitParameters
+    public initForTests({seeds, overrides, rules}: InitParameters
     ): void {
         this.overrides.clear();
         if (overrides != null) {
             this.overrides = overrides;
         }
-        this.client = this.createClient(seeds);
+        this.client = this.createClient(seeds, rules);
     }
 
     /// Force a refresh of toggles from the server
@@ -72,15 +73,15 @@ export class UptechGrowthBookTypescriptWrapper {
         return togl + featureId.toLocaleUpperCase().replace(/-/g, '_')
     }
 
-    private createClient(seeds: Map<string, any>): GrowthBook {
+    private createClient(seeds: Map<string, any>, rules?: Array<Map<string, any>>): GrowthBook {
         return new GrowthBook({
             enabled: true,
             qaMode: false,
             trackingCallback: (gbExperiment, gbExperimentResult) => {},
-            features: this.seedsToGBFeatures(seeds),
+            features: this.seedsToGBFeatures(seeds, rules),
         });
     }
-    private seedsToGBFeatures(seeds: Map<string, any>): Record<string, FeatureDefinition> {
+    private seedsToGBFeatures(seeds: Map<string, any>, rules?: Array<Map<string, any>>): Record<string, FeatureDefinition> {
         if (seeds == null) {
             return {};
         }


### PR DESCRIPTION
The intention for this change is to be able to add a list of
rules to the test init function. These are needed to correctly
mock the features with override values that we get from
Growthbook. This is the first step needed to set attributes
on and after init.

For example, if the following rules argument is passed to the test
init function:
```[
    {
      'condition': {
        'version': {'$gt': '1.0.0'}
      },
      'force': true
    }
];```
The test client will be able to check for a 'version' attribute and
toggle the feature on or off based on the attribute's value (will
toggle on if the value is greater than 1.0.0.

[changelog]
added: rules parameter to test init function

<!-- ps-id: 43ed9329-b74c-46f1-8cf8-1364b1f2193f -->