### PR TITLE
[UE-5] Add attributes parameter to init

### DIFF
--- a/src/uptech-growthbook-wrapper.test.ts
+++ b/src/uptech-growthbook-wrapper.test.ts
@@ -60,6 +60,121 @@ describe("Uptech Growthbook Wrapper", () => {
             expect(instance.isOn('some-feature-name')).toEqual(true);
           });
         });
+
+        describe('when the attribute is added on init', () => {
+          const instance = new UptechGrowthBookTypescriptWrapper('https://cdn.growthbook.io/api/features/dummy-api-key');
+          describe('and the major in the attribute is greater than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                rules: [{
+                  'condition': {
+                    'version': {'$gt': '1.0.0'}
+                  },
+                  'force': true
+                }],
+                attributes: new Map<string, any>().set('version', '1.0.1'),
+              });
+            });
+            it('returns true', () => {
+              expect(instance.isOn('some-feature-name')).toEqual(true);
+            });
+          });
+
+          describe('and the minor in the attribute is greater than the rules', () => {
+              beforeEach(() => {
+                instance.initForTests({
+                  seeds: new Map<string, any>().set('some-feature-name', false),
+                  rules: [{
+                    'condition': {
+                      'version': {'$gt': '1.0.1'}
+                    },
+                    'force': true
+                  }],
+                  attributes: new Map<string, any>().set('version', '1.1.0'),
+                });
+              });
   
+            it('returns true', () => {
+              expect(instance.isOn('some-feature-name')).toEqual(true);
+            });
+          });
+
+          describe('and the patch in the attribute is greater than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                rules: [{
+                  'condition': {
+                    'version': {'$gt': '1.0.1'}
+                  },
+                  'force': true
+                }],
+                attributes: new Map<string, any>().set('version', '1.0.9'),
+              });
+            });
+
+          it('returns true', () => {
+            expect(instance.isOn('some-feature-name')).toEqual(true);
+          });
+        });
+
+          describe('and the major in the attribute is less than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                attributes: new Map<string, any>().set('version', '0.0.9'),
+                'rules': [{
+                  'condition': {
+                    'version': {'$gt': '1.0.0'}
+                  },
+                  'force': true
+                }],
+              });
+            });
+  
+            it('returns false', () => {
+              expect(instance.isOn('some-feature')).toEqual(false);
+            });
+          });
+
+          describe('and the minor in the attribute is less than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                attributes: new Map<string, any>().set('version', '1.0.9'),
+                'rules': [{
+                  'condition': {
+                    'version': {'$gt': '1.1.0'}
+                  },
+                  'force': true
+                }],
+              });
+            });
+  
+            it('returns false', () => {
+              expect(instance.isOn('some-feature')).toEqual(false);
+            });
+          });
+
+          describe('and the patch in the attribute is less than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                attributes: new Map<string, any>().set('version', '1.0.1'),
+                'rules': [{
+                  'condition': {
+                    'version': {'$gt': '1.0.2'}
+                  },
+                  'force': true
+                }],
+              });
+            });
+  
+            it('returns false', () => {
+              expect(instance.isOn('some-feature')).toEqual(false);
+            });
+          });
+        });
     });
   });


### PR DESCRIPTION
The intention for this change is to be able to add attributes
from the app (ie version number) to the init functions. This
allows for version baselining or checking any other attributes
that can be obtained on initialization of the app.

The attributes are saved to a value on the class and used in the
create client method when creating the instance of Growthbook.
Tests for this  functionality use a version number attribute to test
against rules that dictate the app should be a certain version or
higher to use the mock feature.

[changelog]
added: attributes parameter to init

<!-- ps-id: e48509ea-b603-483c-be2a-0df4a8ba223b -->