### PR TITLE
[UE-5] Add public set attribute method

### DIFF
--- a/src/uptech-growthbook-wrapper.test.ts
+++ b/src/uptech-growthbook-wrapper.test.ts
@@ -176,5 +176,121 @@ describe("Uptech Growthbook Wrapper", () => {
             });
           });
         });
+
+        describe('when the attribute is added after init', () => {
+          const instance = new UptechGrowthBookTypescriptWrapper('https://cdn.growthbook.io/api/features/dummy-api-key');
+          describe('and the major in the attribute is greater than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                'rules': [{
+                  'condition': {
+                    'version': {'$gt': '1.0.0'}
+                  },
+                  'force': true
+                }],
+              });
+              instance.setAttributes(new Map<string, any>().set('version', '2.0.1'));
+            });
+            it('returns true', () => {
+              expect(instance.isOn('some-feature-name')).toEqual(true);
+            });
+          });
+
+          describe('and the minor in the attribute is greater than the rules', () => {
+              beforeEach(() => {
+                instance.initForTests({
+                  seeds: new Map<string, any>().set('some-feature-name', false),
+                  rules: [{
+                    'condition': {
+                      'version': {'$gt': '1.0.1'}
+                    },
+                    'force': true
+                  }],
+                });
+                instance.setAttributes(new Map<string, any>().set('version', '1.1.0'));
+              });
+  
+            it('returns true', () => {
+              expect(instance.isOn('some-feature-name')).toEqual(true);
+            });
+          });
+
+          describe('and the patch in the attribute is greater than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                rules: [{
+                  'condition': {
+                    'version': {'$gt': '1.0.1'}
+                  },
+                  'force': true
+                }],
+              });
+              instance.setAttributes(new Map<string, any>().set('version', '1.0.9'));
+            });
+
+          it('returns true', () => {
+            expect(instance.isOn('some-feature-name')).toEqual(true);
+          });
+        });
+
+          describe('and the major in the attribute is less than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                'rules': [{
+                  'condition': {
+                    'version': {'$gt': '1.0.0'}
+                  },
+                  'force': true
+                }],
+              });
+              instance.setAttributes(new Map<string, any>().set('version', '0.0.9'));
+            });
+  
+            it('returns false', () => {
+              expect(instance.isOn('some-feature')).toEqual(false);
+            });
+          });
+
+          describe('and the minor in the attribute is less than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                'rules': [{
+                  'condition': {
+                    'version': {'$gt': '1.1.0'}
+                  },
+                  'force': true
+                }],
+              });
+              instance.setAttributes(new Map<string, any>().set('version', '1.0.9'));
+            });
+  
+            it('returns false', () => {
+              expect(instance.isOn('some-feature')).toEqual(false);
+            });
+          });
+
+          describe('and the patch in the attribute is less than the rules', () => {
+            beforeEach(() => {
+              instance.initForTests({
+                seeds: new Map<string, any>().set('some-feature-name', false),
+                'rules': [{
+                  'condition': {
+                    'version': {'$gt': '1.0.2'}
+                  },
+                  'force': true
+                }],
+              });
+              instance.setAttributes(new Map<string, any>().set('version', '1.0.1'));
+            });
+  
+            it('returns false', () => {
+              expect(instance.isOn('some-feature')).toEqual(false);
+            });
+          });
+        });
     });
   });

--- a/src/uptech-growthbook-wrapper.ts
+++ b/src/uptech-growthbook-wrapper.ts
@@ -60,6 +60,10 @@ export class UptechGrowthBookTypescriptWrapper {
         }
     }
 
+    public setAttributes(attributes: Map<string, any>): void {
+        this.client.setAttributes(this.getGBAttributes(attributes));
+    }
+
     /// Check if a feature is on/off
     public isOn(featureId: string): boolean {
         const hasOverride = ([...this.overrides.keys()]).some(key => key == featureId);
@@ -88,7 +92,7 @@ export class UptechGrowthBookTypescriptWrapper {
             enabled: true,
             qaMode: false,
             trackingCallback: (gbExperiment, gbExperimentResult) => {},
-            attributes: this.getGBAttributes(),
+            attributes: this.getGBAttributes(this.attributes),
             features: this.seedsToGBFeatures(seeds, rules),
         });
     }
@@ -103,12 +107,12 @@ export class UptechGrowthBookTypescriptWrapper {
         return features;
     }
 
-    private getGBAttributes(): Record<string, any> {
-        if (this.attributes == null) {
+    private getGBAttributes(attributes: Map<string, any>): Record<string, any> {
+        if (attributes == null) {
             return {};
         }
         const features = {};
-        this.attributes.forEach((value, key) => {
+        attributes.forEach((value, key) => {
             features[key] = value;
         })
         return features;


### PR DESCRIPTION
The intention for this change is to give users the ability to add
attributes after the wrapper has been initialized. This is helpful
in instances where required attributes cannot be acquired until
long after an app is initialized. For instance, with canary testing
a feature will only be available to select users. The user's id
cannot be determined until after they have logged in.

To achieve this, a new public method has been added to the
wrapper that takes in an attributes parameter. If the client
already has attributes (ie they were added during init), the
new attributes are added alongside the old attributes.
Otherwise, the new attributes are assigned to the client
using the existing `setAttributes` method from the sdk.

The tests tests all possible permutations of a different version
number to ensure version comparison is working properly in
node.

[changelog]
added: public set attribute method

<!-- ps-id: 17ee3ac6-d2dc-45f8-81c1-131ee71ad296 -->