### PR TITLE
[UE-29] Document updating attributes after init

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ sampleApplyFee(amount: number): number {
   }
 }
 ```
+
+### Set attributes
+Additional attributes can be set after initialization. This is a common use case in which an id attribute is set after user login (useful for canary testing). 
+```javascript
+import { Togls } from 'yourproject/togls.ts';
+sampleLogIn(): void {
+  const userId = await login(); // Fake method that logs in user and gets user id
+  Togls.instance.setAttributes({'id': userId});
+}
+```
+
 ### Control toggles in automated tests
 
 ```javascript


### PR DESCRIPTION
The reason for this change is to give users of this package
instruction on how to use the setAttribute method. The
example shows how they might add a user id attribute in their
login logic.

Please note that there are no instructions on adding the users
for canary testing within the Growthbook GUI or fetching the
user id after log in, as this is out of scope for the package.

[changelog]
added: 'Set attribute' section in README

<!-- ps-id: 90f8d6b2-5bc2-47f4-abec-8aa953e8c569 -->