### PR TITLE
[UE-39] Fetch non-boolean toggle state

### DIFF
--- a/src/uptech-growthbook-wrapper.test.ts
+++ b/src/uptech-growthbook-wrapper.test.ts
@@ -293,4 +293,49 @@ describe("Uptech Growthbook Wrapper", () => {
           });
         });
     });
-  });
+
+    describe('value', () => {
+      const instance = new UptechGrowthBookTypescriptWrapper('https://cdn.growthbook.io/api/features/dummy-api-key');
+      const features = new Map<string, any>();
+        features.set('string-value-feature', 'value')
+        features.set('int-value-feature', 1)
+        features.set('bool-value-feature', true)
+      describe('when no value is found for the feature', () => {
+        
+        beforeEach(() => {
+          instance.initForTests({seeds: features});
+        });
+
+        it('returns null', () => {
+          expect(instance.value('some-other-feature')).toEqual(null);
+        });
+      });
+
+      describe('when a feature value is present', () => {
+        beforeEach(() => {
+          instance.initForTests({seeds: features});
+        });
+
+        it('returns the feature value', () => {
+          expect(
+              instance.value('string-value-feature')).toEqual('value');
+          expect(instance.value('int-value-feature')).toEqual(1);
+          expect(instance.value('bool-value-feature')).toEqual(true);
+        });
+      });
+
+      describe('when an override is present', () => {
+        beforeEach(() => {
+          instance.initForTests({overrides: features});
+        });
+
+        it('returns the overridden value', () => {
+          expect(
+            instance.value('string-value-feature')).toEqual('value');
+        expect(instance.value('int-value-feature')).toEqual(1);
+        expect(instance.value('bool-value-feature')).toEqual(true);
+        });
+      });
+    });
+
+});

--- a/src/uptech-growthbook-wrapper.ts
+++ b/src/uptech-growthbook-wrapper.ts
@@ -66,7 +66,7 @@ export class UptechGrowthBookTypescriptWrapper {
 
     /// Check if a feature is on/off
     public isOn(featureId: string): boolean {
-        const hasOverride = ([...this.overrides.keys()]).some(key => key == featureId);
+        const hasOverride = this.overrides.has(featureId);
 
         if (hasOverride) {
             const value = this.overrides.get(featureId);
@@ -80,6 +80,18 @@ export class UptechGrowthBookTypescriptWrapper {
             }
             return this.client.feature(featureId).on ?? false;
         }
+    }
+
+    /// Return the value of a feature.
+    /// If the feature does not have a value configured, returns null.
+    public value(featureId: string): any {
+      const hasOverride = this.overrides.has(featureId);
+    
+      if (hasOverride) {
+        return this.overrides.get(featureId);
+      }
+    
+      return this.client.getFeatureValue(featureId, null);
     }
 
     private getOverrideKeyById(featureId: string): string {


### PR DESCRIPTION
The reason for this change is to give users of this package
a public method to get the value of a feature. Previously,
they could only retrieve whether a feature was on or off.
This allows them to use the non boolean value in their
applications

[changelog]
added: get value method in wrapper

<!-- ps-id: d8707451-6c50-405c-ad24-c983f685dad8 -->
