### PR TITLE
[UE-26] Document non-boolean toggle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ sampleApplyFee(amount: number): number {
 }
 ```
 
+### Evaluate Feature value
+```javascript
+import { Togls } from 'yourproject/togls.ts';
+
+sampleApplyFee(amount: number): number {
+  // Note: feature value can be of any type
+  const featureValue = Togls.instance.value('example-toggle-higher-fee');
+  if (featureValue != 0) {
+    return amount + 20;
+  } else {
+    return amount + 10;
+  }
+}
+```
+
 ### Set attributes
 Additional attributes can be set after initialization. This is a common use case in which an id attribute is set after user login (useful for canary testing). 
 ```javascript


### PR DESCRIPTION
The reason for this change is to give users of this package
instruction on how to use the value method. The example
shows how they might get a feature's value (in this case
an int) and use it to determine some business logic.

[changelog]
added: 'Evaluate Feature value' section in README

<!-- ps-id: 4fb8f63e-8ec4-43cc-87ee-dbbdc45047c4 -->