### PR TITLE
Remove "flutter" references from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Uptech GrowthBook SDK Flutter Wrapper
+## Uptech GrowthBook SDK Wrapper
 
-This project is a thin wrapper around the [GrowthBook Flutter SDK](https://github.com/growthbook/growthbook) so that we
+This project is a thin wrapper around the [GrowthBook SDK](https://github.com/growthbook/growthbook) so that we
 can use the [GrowthBook][] service to manage feature toggles while also being
 able to manage toggle states properly within automated test suites.
 


### PR DESCRIPTION
This updates the readme to remove leftover usages of "flutter" in the SDK, since this repo doesn't have anything to do with that and it was confusing

skip_ticket_id_check

<!-- ps-id: 27478c9a-d3ad-4978-848c-5de4e3dc8117 -->