### PR TITLE
Expose InitParameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { UptechGrowthBookTypescriptWrapper } from './uptech-growthbook-wrapper';
+export { InitParameters, UptechGrowthBookTypescriptWrapper } from './uptech-growthbook-wrapper';

--- a/src/uptech-growthbook-wrapper.ts
+++ b/src/uptech-growthbook-wrapper.ts
@@ -1,9 +1,13 @@
-import { FeatureDefinition, GrowthBook, setPolyfills } from "@growthbook/growthbook";
-import cross_fetch from 'cross-fetch';
+import cross_fetch from 'cross-fetch'
+import {
+  FeatureDefinition,
+  GrowthBook,
+  setPolyfills,
+} from '@growthbook/growthbook'
 
 setPolyfills({ fetch: cross_fetch });
 
-interface InitParameters {
+export interface InitParameters {
   seeds?: Map<string, any>,
   overrides?: Map<string, any>,
   attributes?: Map<string, any>,


### PR DESCRIPTION
This allows for consumers of the library to leverage this interface so that they do not need to replicate it and create their own.

Fixes: Expose InitParameters #21

<!-- ps-id: 947a72a4-06e6-4dbf-83ff-3d53ea22df21 -->